### PR TITLE
Replace reference to OverlayBaseApp with OverlayBaseWidget

### DIFF
--- a/snappysonic/overlay_widget/overlay.py
+++ b/snappysonic/overlay_widget/overlay.py
@@ -5,7 +5,7 @@ from packaging import version
 from PySide2.QtWidgets import QLabel, QWidget
 from cv2 import (rectangle, putText, circle, imread)
 from numpy import zeros, uint8
-from sksurgeryutils.common_overlay_apps import OverlayBaseApp
+from sksurgeryutils.common_overlay_apps import OverlayBaseWidget
 from sksurgeryimage.utilities.weisslogo import WeissLogo
 from sksurgeryarucotracker import __version__ as arucoversion
 from snappysonic.algorithms.algorithms import (configure_tracker,
@@ -15,9 +15,9 @@ from snappysonic.algorithms.algorithms import (configure_tracker,
                                                numpy_to_qpixmap)
 
 
-class OverlayApp(OverlayBaseApp):
+class OverlayApp(OverlayBaseWidget):
     """
-    Inherits from OverlayBaseApp,
+    Inherits from OverlayBaseWidget,
     adding code to read in video buffers, and display a frame
     of data that depends on the position of an external tracking system,
     e.g. surgeryarucotracker


### PR DESCRIPTION
SciKitSurgery/utils project renamed "OverlayBaseApp" to "OverlayBaseWidget", acknowledging the fact that the class defines a widget and not an app: https://github.com/SciKit-Surgery/scikit-surgeryutils/commit/e6f6149131e1492a7ffe6d297c0b664d225e3534

The outdated reference prevented the project from running on my setup. Please note that this PR is just a hotfix and I didn't check what other parts of the code were touched by the changes in scikit surgery.